### PR TITLE
ISSUE-5: make URL relative in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "parts/gobilda"]
 	path = parts/gobilda
-	url = https://github.com/openvmp/openvmp-parts-gobilda.git
+	url = ../openvmp-parts-gobilda.git


### PR DESCRIPTION
[Problem]
- I created forks of openvmp repos. I cloned cdhabecker/openvmp and then initialized and updated the submodules. The submodules of openvmp/openvmp use  relative URLs, which means that cdhabecker/openvmp retrieved the submodules as  cdhabecker/ forks of those openvmp repos. However, since the gobilda submodule is an absolute URL, my environment cloned openvmp/openvmp-parts-gobilda instead of cdhabecker/openvmp-parts-gobilda.

[Solution]
- Made it a relative URL.

[Test]
- Initialized the submodule and verified that it was a clone of  cdhabecker/openvmp-parts-gobilda.

[Links]
- https://github.com/openvmp/openvmp-models/issues/5